### PR TITLE
added basic user styling to user messages, currently only displays html

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -76,7 +76,9 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String userEnteredContent = request.getParameter("text");
+    Whitelist whitelist = Whitelist.basic();
+    String text = Jsoup.clean(userEnteredContent, whitelist);
 
     Message message = new Message(user, text);
     datastore.storeMessage(message);


### PR DESCRIPTION
I removed the restrictive whitelist to allow for some styling. Here is how some of the tags in work right now. Right now it only currently works with html tags, however I am working on parsing the BBcode into html tags.
![image](https://user-images.githubusercontent.com/29179624/59130858-3f045a80-8936-11e9-98d1-ec08a75baea0.png)
