### PR TITLE
[bug fix] listing was saved as message rather than listing

### DIFF
--- a/src/main/java/com/google/codeu/servlets/FormHandlerServlet.java
+++ b/src/main/java/com/google/codeu/servlets/FormHandlerServlet.java
@@ -35,6 +35,8 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.google.codeu.data.Listing;
+
 /**
  * When the user submits the form, Blobstore processes the file upload and then
  * forwards the request to this servlet. This servlet can then process the
@@ -104,10 +106,16 @@ public class FormHandlerServlet extends HttpServlet {
         String replacement = "<img src=\"$1\" />";
         String textWithImagesReplaced = userText.replaceAll(regex, replacement);
 
-        Message message = new Message(user, textWithImagesReplaced);
-        datastore.storeMessage(message);
-
-        response.sendRedirect("/user-page.html?user=" + user);
+        if(request.getParameter("title") != null) {
+            Listing listing = new Listing(user, request.getParameter("title"), textWithImagesReplaced);
+            datastore.storeListing(listing);
+            response.sendRedirect("/sell.html?user=" + user);
+        }
+        else {
+            Message message = new Message(user , textWithImagesReplaced);
+            datastore.storeMessage(message);
+            response.sendRedirect("/user-page.html?user=" + user);
+        }
     }
 
     /**


### PR DESCRIPTION
Since the listing object was not being stored due to FormHandlerServlet only saving message objects I adjusted some of the code. 

Since the only distinguishing factor of listing from message right now is that listing contains a title, I decided to check if the request even has an html tag with an attribute set to name='title'. If it does then we would create a Listing object from the user input and then store it in the Datastore object. 

If it does not contain an html tag with an attribute of name='title' then we would determine that it is a message and then create the Message object and store it in the datastore.