### PR TITLE
modified marker to let it link to single post

### DIFF
--- a/src/main/java/com/google/codeu/data/Marker.java
+++ b/src/main/java/com/google/codeu/data/Marker.java
@@ -1,15 +1,19 @@
 package com.google.codeu.data;
 
+import java.util.UUID;
+
 public class Marker {
 
   private double lat;
   private double lng;
   private String content;
+  private UUID markerid;
 
-  public Marker(double lat, double lng, String content) {
+  public Marker(double lat, double lng, String content, UUID markerid) {
     this.lat = lat;
     this.lng = lng;
     this.content = content;
+    this.markerid=markerid;
   }
 
   public double getLat() {
@@ -22,5 +26,9 @@ public class Marker {
 
   public String getContent() {
     return content;
+  }
+
+  public UUID getMarkerid(){
+    return markerid;
   }
 }

--- a/src/main/java/com/google/codeu/servlets/MarkerDataServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MarkerDataServlet.java
@@ -14,6 +14,7 @@ import com.google.codeu.data.Datastore;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -52,21 +53,27 @@ public class MarkerDataServlet extends HttpServlet {
 
   }
 
-  /** Fetches markers from Datastore. */
+  /** Fetches markers from listing. */
   private List<Marker> getMarkers() {
     List<Marker> markers = new ArrayList<>();
+    List<Listing>allListings=datastore.getAllListings();
 
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Query query = new Query("Marker");
-    PreparedQuery results = datastore.prepare(query);
+    String markerContent=null;
+    UUID id = null;
 
-    for (Entity entity : results.asIterable()) {
-      double lat = (double) entity.getProperty("lat");
-      double lng = (double) entity.getProperty("lng");
-      String content = (String) entity.getProperty("content");
+    for(int i=0; i<allListings.size();i++){
 
-      Marker marker = new Marker(lat, lng, content);
-      markers.add(marker);
+      Listing listingObject = allListings.get(i);
+
+      if(!listingObject.getTitle().equals("marker_in_map")){
+        markerContent = listingObject.getTitle();
+        id=listingObject.getId();
+      }else{
+        double lat = listingObject.getLat();
+        double lng = listingObject.getLng();
+        Marker marker = new Marker (lat, lng,markerContent,id);
+        markers.add(marker);
+      }
     }
     return markers;
   }
@@ -97,7 +104,7 @@ public class MarkerDataServlet extends HttpServlet {
         Listing listing = new Listing(user,"marker_in_map", null, lat, lng, content);
         datastore.storeListing(listing);
 
-        Marker marker = new Marker(lat, lng, content);
+        Marker marker = new Marker(lat, lng, content, null);
         storeMarker(marker);
       }
     }

--- a/src/main/webapp/js/map-loader.js
+++ b/src/main/webapp/js/map-loader.js
@@ -109,20 +109,21 @@ function fetchMarkers(){
         return response.json();
     }).then((markers) => {
         markers.forEach((marker) => {
-            createMarkerForDisplay(marker.lat, marker.lng, marker.content)
+            createMarkerForDisplay(marker.lat, marker.lng, marker.content, marker.markerid)
         });
     });
 }
 /** Creates a marker that shows a read-only info window when clicked. */
-function createMarkerForDisplay(lat, lng, content){
+function createMarkerForDisplay(lat, lng, content, markerid){
     const marker = new google.maps.Marker({
         position: {lat: lat, lng: lng},
         map: map
     });
     var infoWindow = new google.maps.InfoWindow({
-        content: content
+        content:"<div>"+content+"<br><button onclick=\"\location.href = 'viewListing.html?id="+markerid+"';\"\ >To The Post</button></div>"
+
     });
     marker.addListener('click', () => {
-        infoWindow.open(map, marker);
+       infoWindow.open(map, marker);
     });
 }

--- a/src/main/webapp/js/sellMap-loader.js
+++ b/src/main/webapp/js/sellMap-loader.js
@@ -10,8 +10,6 @@ function createMap() {
     map.addListener('click', (event) => {
         createMarkerForEdit(event.latLng.lat(), event.latLng.lng());
     });
-    //not allow user to see other markers
-   // fetchMarkers();
 
 
     //Get user location and show an open window with information
@@ -108,16 +106,6 @@ function handleLocationError(browserHasGeolocation, infoWindow, pos) {
     infoWindow.open(map);
 }
 
-/** Fetches markers from the backend and adds them to the map. */
-function fetchMarkers(){
-    fetch('/markers').then((response) => {
-        return response.json();
-    }).then((markers) => {
-       markers.forEach((marker) => {
-           createMarkerForDisplay(marker.lat, marker.lng, marker.content)
-       });
-    });
-}
 /** Creates a marker that shows a read-only info window when clicked. */
 function createMarkerForDisplay(lat, lng, content){
     const marker = new google.maps.Marker({
@@ -164,16 +152,18 @@ function createMarkerForEdit(lat, lng){
 }
 /** Builds and returns HTML elements that show an editable textbox and a submit button. */
 function buildInfoWindowInput(lat, lng){
-    const textBox = document.createElement('textarea');
+   // const textBox = document.createElement('textarea');
     const button = document.createElement('button');
     button.appendChild(document.createTextNode('Submit'));
     button.onclick = () => {
-        postMarker(lat, lng, textBox.value);
-        createMarkerForDisplay(lat, lng, textBox.value);
+        //postMarker(lat, lng, textBox.value);
+        //createMarkerForDisplay(lat, lng, textBox.value);
+        postMarker(lat, lng, null);
+        createMarkerForDisplay(lat, lng, null);
         editMarker.setMap(null);
     };
     const containerDiv = document.createElement('div');
-    containerDiv.appendChild(textBox);
+    //containerDiv.appendChild(textBox);
     containerDiv.appendChild(document.createElement('br'));
     containerDiv.appendChild(button);
     return containerDiv;

--- a/src/main/webapp/sell.html
+++ b/src/main/webapp/sell.html
@@ -78,8 +78,8 @@ limitations under the License.
             <textarea name="text" id="message-input"></textarea>
             <br />
             <h4>Where are you going to make the sales?</h4>
-            <p>You can mark the map and put the content on the marker: time, notes, etc.  <br />
-                Your markers can be displayed in <a href="/map.html">Google Map</a> page.</p>
+            <p>You can mark the map.<br />
+                Your markers with title can be displayed in <a href="/map.html">Google Map</a> page.</p>
             <div class="row">
             <input id="pac-input" class="controls" type="text" placeholder="Enter an address">
             <div id="map" class="text-center"></div>


### PR DESCRIPTION
Delete the textbox when the user makes the marker
![image](https://user-images.githubusercontent.com/44527365/61166616-7ef2ca80-a4fe-11e9-9bce-8512fb280f32.png)

The marker shows the same content as the title of the post.
![image](https://user-images.githubusercontent.com/44527365/61166621-84501500-a4fe-11e9-8728-aefb2dbe08c0.png)

When the user clicks "to the post" button, the page automatically redirects to the single post page.
![image](https://user-images.githubusercontent.com/44527365/61166624-87e39c00-a4fe-11e9-97df-c77e0f3d6d11.png)
